### PR TITLE
Fixed MINOR version for automatic packaging

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -1,4 +1,4 @@
-local MAJOR, MINOR = "ScrollingTable", tonumber("@project-timestamp@");
+local MAJOR, MINOR = "ScrollingTable", tonumber("@project-timestamp@") or 40300;
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR);
 if not lib then
 	return; -- Already loaded and no upgrade necessary.


### PR DESCRIPTION
Commit 1f908c0a58bf78e44f348fc1e33597943b693121 breaks loading of the library in game, because "@project-timestamp@" is not a number. Stumbled over this when updating and repackaging one of my addons, which failed to load while testing.

Pull request is for an immediate fix and a guess based on the version number of the last tag. Feel free to change it.