### PR TITLE
Fix parent anchor on SetPoint

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -718,7 +718,7 @@ do
 
 		f:SetBackdrop(ScrollPaneBackdrop);
 		f:SetBackdropColor(0.1,0.1,0.1);
-		f:SetPoint("CENTER",UIParent,"CENTER",0,0);
+		f:SetPoint("CENTER",parent or UIParent,"CENTER",0,0);
 
 		-- build scroll frame
 		local scrollframe = CreateFrame("ScrollFrame", f:GetName().."ScrollFrame", f, "FauxScrollFrameTemplate");


### PR DESCRIPTION
In response to the last comment posted [here](https://www.wowace.com/projects/lib-st/pages/create-st).

Currently, CreateST ignores the provided `parent` parameter and always anchors the table to the center of UIParent. This PR fixes that, so that it will be anchored to the center of the parent frame if provided, otherwise will fall back on UIParent.

Tested with and without the `parent` parameter, works as expected. Can provide screenshots if needed. Thanks for the awesome library!