### PR TITLE
New Feature: Multi select

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -518,7 +518,11 @@ do
 	-- @description Gets the currently selected to row.  Return will be the unaltered index of the data row that is selected.
 	-- @usage st:GetSelection()
 	local function GetSelection(self)
-		return self.selected;
+		if self.multiselection then
+			return self.selected:Get()
+		else
+			return self.selected;
+		end
 	end
 
 	--- API for a ScrollingTable table
@@ -749,7 +753,7 @@ do
 							selected = (table:GetSelection() == realrow)
 						end
 						if selected then
-							table:ClearSelection();
+							table:ClearSelection(realrow);
 						else
 							table:SetSelection(realrow);
 						end

--- a/Core.lua
+++ b/Core.lua
@@ -742,7 +742,13 @@ do
 						table:SortData();
 
 					else
-						if table:GetSelection() == realrow then
+						local selected
+						if table.multiselection then
+							selected = (table.selected and table.selected:IsSelected(realrow))
+						else
+							selected = (table:GetSelection() == realrow)
+						end
+						if selected then
 							table:ClearSelection();
 						else
 							table:SetSelection(realrow);

--- a/Core.lua
+++ b/Core.lua
@@ -498,7 +498,18 @@ do
 	-- @description Sets the currently selected row to 'realrow'.  Realrow is the unaltered index of the data row in your table. You should not need to refresh the table.
 	-- @usage st:SetSelection(12)
 	local function SetSelection(self, realrow)
-		self.selected = realrow;
+    if self.multiselection then
+      if realrow then
+        local selected = self:GetRow(realrow)
+        if selected and selected.cols then -- Handle column titles click
+          self.selected:Set(realrow);
+        end
+      else
+        self.selected:Clear();
+      end
+    else
+		  self.selected = realrow;
+    end
 		self:Refresh();
 	end
 
@@ -570,7 +581,13 @@ do
 			end
 
 			if table.fSelect then
-				if table.selected == realrow then
+        local selected = false
+        if table.multiselection then
+          selected = (table.selected and table.selected:IsSelected(realrow))
+        else
+				  selected = (table.selected == realrow)
+        end
+        if selected then
 					table:SetHighLightColor(rowFrame, highlight or cols[column].highlight or rowdata.highlight or table:GetDefaultHighlight());
 				else
 					table:SetHighLightColor(rowFrame, table:GetDefaultHighlightBlank());
@@ -633,14 +650,14 @@ do
 		return false;
 	end
 
-	function lib:CreateST(cols, numRows, rowHeight, highlight, parent)
+	function lib:CreateST(cols, numRows, rowHeight, highlight, parent, multiselection)
 		local st = {};
 		self.framecount = self.framecount or 1;
 		local f = CreateFrame("Frame", "ScrollTable" .. self.framecount, parent or UIParent, BackdropTemplateMixin and "BackdropTemplate");
 		self.framecount = self.framecount + 1;
 		st.showing = true;
 		st.frame = f;
-
+    st.multiselection = multiselection or false
 		st.Show = Show;
 		st.Hide = Hide;
 		st.SetDisplayRows = SetDisplayRows;
@@ -695,7 +712,13 @@ do
 				if row and realrow then
 					local rowdata = table:GetRow(realrow);
 					local celldata = table:GetCell(rowdata, column);
-					if realrow ~= table.selected or not table.fSelect then
+          local emptySelection
+          if table.multiselection then
+            emptySelection = (not table.selected or not table.selected:IsSelected(realrow) or not table.fSelect)
+          else
+            emptySelection = (realrow ~= table.selected or not table.fSelect)
+          end
+					if emptySelection then
 						table:SetHighLightColor(rowFrame, table:GetDefaultHighlightBlank());
 					end
 				end
@@ -734,7 +757,30 @@ do
 		f:SetBackdrop(ScrollPaneBackdrop);
 		f:SetBackdropColor(0.1,0.1,0.1);
 		f:SetPoint("CENTER",parent or UIParent,"CENTER",0,0);
+    if multiselection then
+      local multiselector = { _storage =  {} }
+      multiselector.Set = (function(self, realrow)
+          self._storage[realrow] = true
+      end)
+      multiselector.Get = (function(self)
+        local keyList = {}
+        local n = 0
 
+        for k,_ in pairs(self._storage) do
+          n = n + 1
+          keyList[n] = k
+        end
+        return keyList
+      end)
+      multiselector.Clear = (function(self)
+        self._storage = {}
+      end)
+      multiselector.IsSelected = (function(self, realrow)
+        return self._storage[realrow]
+      end)
+
+      st.selected = multiselector
+    end
 		-- build scroll frame
 		local scrollframe = CreateFrame("ScrollFrame", f:GetName().."ScrollFrame", f, "FauxScrollFrameTemplate");
 		st.scrollframe = scrollframe;


### PR DESCRIPTION
Adds multiselect option to the library.
It's added in a non-breaking way, so the old single select is still functional.

* Multi selection is chosen by new parameter during scrolltable creation.
* API changes in a way that GetSelection returns list (ordered by selection as its based on realrow internally) for multiselect mode
* Clicking on any selected option clears whole selection