### PR TITLE
Update Core.lua

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -13,7 +13,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-local MAJOR, MINOR = "ScrollingTable", tonumber("@project-timestamp@") or 40300;
+local MAJOR, MINOR = "ScrollingTable", tonumber("@project-timestamp@") or 41300;
 local lib, oldminor = LibStub:NewLibrary(MAJOR, MINOR);
 if not lib then
 	return; -- Already loaded and no upgrade necessary.


### PR DESCRIPTION
The minor version number should be increased when we release new minor versions.

When not packaging using a `.pkgmeta` the libstub minor version falls back to a default.
This default should be increased every release.

(Practically: there is no need to use the `@project-timestamp@` tag when you do that, I think LibStub recommends against using a timestamp or revision kind of value)